### PR TITLE
Fix Manual Installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ git clone http://github.com/techwizrd/fishmarks.git
 
 ```fish
 # Load fishmarks (http://github.com/techwizrd/fishmarks)
-. ~/.fishmarks/marks.fish
+source ~/.fishmarks/marks.fish
 ```
 ### Update to the latest version
 


### PR DESCRIPTION
My fish linter complains about a line
```sh
. ~/.fishmarks/marks.fish
```
with an error

> The file '.' is not executable by this user

so I changed `.` to `source`.
